### PR TITLE
Library focus

### DIFF
--- a/res/skins/Deere/style.qss
+++ b/res/skins/Deere/style.qss
@@ -129,8 +129,22 @@ QTableView, QTreeView {
   border: 1px solid #1A1A1A;
 }
 
-QTreeView::branch:selected, QTableView::item:selected, QTreeView::item:selected {
+QTreeView::branch {
+  background-color: #1F1F1F;
+}
+ 
+QTableView::item:selected:active, 
+QTreeView::item:selected:active {
+  color: #ffffff;
+
   background-color: #006596;
+}
+
+
+QTableView::item:selected:!active, 
+QTreeView::item:selected:!active {
+  color: #d2d2d2;
+  background-color: #0d4866;
 }
 
 /* checkbox in library "Played" column */
@@ -145,14 +159,6 @@ QTableView::indicator:checked {
 
 QTableView::indicator:unchecked {
   background: url(skin:/image/style_checkbox_unchecked.png);
-}
-
-WBaseLibrary[showFocus="0"] {
-  border-top: 2px solid transparent;
-}
-
-WBaseLibrary[showFocus="1"] {
-  border-top: 2px solid #0080BE;
 }
 
 /* BPM lock icon in the library "BPM" column. */
@@ -205,7 +211,8 @@ WBaseLibrary QLabel {
   border: 1px solid #1A1A1A;
 }
 
-#LibraryCoverArtSplitter QTabWidget QTreeView, #DlgAutoDJ {
+#LibraryCoverArtSplitter QTabWidget QTreeView, 
+#DlgAutoDJ {
   margin: 0;
   border: none;
 }
@@ -280,6 +287,17 @@ QPushButton#LibraryPreviewButton:!checked {
 
 QPushButton#LibraryPreviewButton:checked {
   image: url(skin:/image/style_library_preview_pause.png);
+}
+
+
+#LibrarySidebarButtons:focus,
+#LibrarySidebarButtons QToolButton:focus,
+#LibrarySidebarExpanded > QWidget:focus,
+#LibrarySidebarExpanded QAbstractScrollArea > QWidget:focus,
+WLibrarySidebar:focus, 
+WLibrary:focus,
+QTableView:focus {
+  border: 1px solid #0080BE;
 }
 
 /* library header row */
@@ -469,6 +487,10 @@ WBaseLibrary QPushButton {
   border: 1px solid #4B4B4B;
   border-radius: 2px;
   outline: none;
+}
+
+WBaseLibrary QPushButton:focus {
+  background-color: #006596;
 }
 
 WBaseLibrary QPushButton:!enabled {

--- a/res/skins/Shade/skin.xml
+++ b/res/skins/Shade/skin.xml
@@ -571,12 +571,14 @@
                         border: 2px solid #e74421;
                     }
 
-                    WBaseLibrary[showFocus="0"] {
-                        border-top: 2px solid transparent;
-                    }
-
-                    WBaseLibrary[showFocus="1"] {
-                        border-top: 2px solid #e74421;
+                    #LibrarySidebarButtons:focus,
+                    #LibrarySidebarButtons QToolButton:focus,
+                    #LibrarySidebarExpanded > QWidget:focus,
+                    #LibrarySidebarExpanded QAbstractScrollArea > QWidget:focus,
+                    WLibrarySidebar:focus, 
+                    WLibrary:focus,
+                    QTableView:focus {
+                      border: 1px solid #e74421;
                     }
 
                     WLibraryBreadCrumb QLabel {

--- a/src/library/features/baseplaylist/baseplaylistfeature.cpp
+++ b/src/library/features/baseplaylist/baseplaylistfeature.cpp
@@ -130,8 +130,8 @@ void BasePlaylistFeature::activate() {
         m_featurePane = preselectedPane;
     }
 
-    auto modelIt = m_lastChildClicked.find(m_featurePane);
-    if (modelIt != m_lastChildClicked.end() &&  (*modelIt).isValid()) {
+    auto modelIt = m_lastChildClicked.constFind(m_featurePane);
+    if (modelIt != m_lastChildClicked.constEnd() &&  (*modelIt).isValid()) {
         qDebug() << "BasePlaylistFeature::activate" << "m_lastChildClicked found";
         // Open last clicked Playlist in the preselectded pane
         activateChild(*modelIt);
@@ -151,7 +151,7 @@ void BasePlaylistFeature::activateChild(const QModelIndex& index) {
         m_featurePane = preselectedPane;
     }
     
-    if (index == m_lastChildClicked[m_featurePane]) {
+    if (index == m_lastChildClicked.value(m_featurePane)) {
         restoreSearch("");
         showTable(m_featurePane);
         switchToFeature();

--- a/src/library/features/baseplaylist/baseplaylistfeature.cpp
+++ b/src/library/features/baseplaylist/baseplaylistfeature.cpp
@@ -172,6 +172,10 @@ void BasePlaylistFeature::activateChild(const QModelIndex& index) {
     }
 }
 
+void BasePlaylistFeature::invalidateChild() {
+    m_lastChildClicked.clear();
+}
+
 void BasePlaylistFeature::activatePlaylist(int playlistId) {
     //qDebug() << "BasePlaylistFeature::activatePlaylist()" << playlistId;
     if (playlistId != -1 && m_pPlaylistTableModel) {

--- a/src/library/features/baseplaylist/baseplaylistfeature.cpp
+++ b/src/library/features/baseplaylist/baseplaylistfeature.cpp
@@ -125,10 +125,7 @@ QPointer<PlaylistTableModel> BasePlaylistFeature::getPlaylistTableModel(int pane
 }
 
 void BasePlaylistFeature::activate() {
-    int preselectedPane = getPreselectedPane();
-    if (preselectedPane >= 0) {
-        m_featurePane = preselectedPane;
-    }
+    adoptPreselectedPane();
 
     auto modelIt = m_lastChildClicked.constFind(m_featurePane);
     if (modelIt != m_lastChildClicked.constEnd() &&  (*modelIt).isValid()) {
@@ -146,10 +143,7 @@ void BasePlaylistFeature::activate() {
 }
 
 void BasePlaylistFeature::activateChild(const QModelIndex& index) {
-    int preselectedPane = getPreselectedPane();
-    if (preselectedPane >= 0) {
-        m_featurePane = preselectedPane;
-    }
+    adoptPreselectedPane();
     
     if (index == m_lastChildClicked.value(m_featurePane)) {
         restoreSearch("");
@@ -317,9 +311,9 @@ void BasePlaylistFeature::slotCreatePlaylist() {
     }
 }
 
-void BasePlaylistFeature::setFeaturePane(int focus) {
+void BasePlaylistFeature::setFeaturePaneId(int focus) {
     m_pPlaylistTableModel = getPlaylistTableModel(focus);
-    LibraryFeature::setFeaturePane(focus);
+    LibraryFeature::setFeaturePaneId(focus);
 }
 
 void BasePlaylistFeature::slotDeletePlaylist() {

--- a/src/library/features/baseplaylist/baseplaylistfeature.h
+++ b/src/library/features/baseplaylist/baseplaylistfeature.h
@@ -41,8 +41,10 @@ class BasePlaylistFeature : public LibraryFeature {
     void analyzeTracks(QList<TrackId>);
 
   public slots:
-    virtual void activate();
-    virtual void activateChild(const QModelIndex& index);
+    void activate() override;
+    void activateChild(const QModelIndex& index) override;
+    void invalidateChild() override;
+
     virtual void activatePlaylist(int playlistId);
     virtual void htmlLinkClicked(const QUrl& link);
 

--- a/src/library/features/baseplaylist/baseplaylistfeature.h
+++ b/src/library/features/baseplaylist/baseplaylistfeature.h
@@ -50,7 +50,7 @@ class BasePlaylistFeature : public LibraryFeature {
     virtual void slotPlaylistContentChanged(int playlistId) = 0;
     virtual void slotPlaylistTableRenamed(int playlistId, QString a_strName) = 0;
     void slotCreatePlaylist();
-    void setFeaturePane(int focus);
+    void setFeaturePaneId(int focus);
 
   protected slots:
     void slotDeletePlaylist();

--- a/src/library/features/crates/cratefeature.cpp
+++ b/src/library/features/crates/cratefeature.cpp
@@ -250,6 +250,10 @@ void CrateFeature::activateChild(const QModelIndex& index) {
     showTrackModel(m_pCrateTableModel);
 }
 
+void CrateFeature::invalidateChild() {
+    m_lastClickedIndex.clear();
+}
+
 void CrateFeature::activateCrate(int crateId) {
     //qDebug() << "CrateFeature::activateCrate()" << crateId;
     m_pCrateTableModel = getTableModel(m_featurePane);
@@ -274,7 +278,7 @@ void CrateFeature::onRightClick(const QPoint& globalPos) {
     menu.exec(globalPos);
 }
 
-void CrateFeature::onRightClickChild(const QPoint& globalPos, QModelIndex index) {
+void CrateFeature::onRightClickChild(const QPoint& globalPos, const QModelIndex& index) {
     //Save the model index so we can get it in the action slots...
     m_lastRightClickedIndex = index;
     int crateId = crateIdFromIndex(index);

--- a/src/library/features/crates/cratefeature.cpp
+++ b/src/library/features/crates/cratefeature.cpp
@@ -224,8 +224,8 @@ void CrateFeature::activate() {
         m_featurePane = preselectedPane;
     }
 
-    auto modelIt = m_lastClickedIndex.find(m_featurePane);
-    if (modelIt != m_lastClickedIndex.end() &&  (*modelIt).isValid()) {
+    auto modelIt = m_lastClickedIndex.constFind(m_featurePane);
+    if (modelIt != m_lastClickedIndex.constEnd() &&  (*modelIt).isValid()) {
         activateChild(*modelIt);
         return;
     }

--- a/src/library/features/crates/cratefeature.cpp
+++ b/src/library/features/crates/cratefeature.cpp
@@ -219,10 +219,7 @@ TreeItemModel* CrateFeature::getChildModel() {
 }
 
 void CrateFeature::activate() {
-    int preselectedPane = getPreselectedPane();
-    if (preselectedPane >= 0) {
-        m_featurePane = preselectedPane;
-    }
+    adoptPreselectedPane();
 
     auto modelIt = m_lastClickedIndex.constFind(m_featurePane);
     if (modelIt != m_lastClickedIndex.constEnd() &&  (*modelIt).isValid()) {
@@ -237,10 +234,7 @@ void CrateFeature::activate() {
 }
 
 void CrateFeature::activateChild(const QModelIndex& index) {
-    int preselectedPane = getPreselectedPane();
-    if (preselectedPane >= 0) {
-        m_featurePane = preselectedPane;
-    }
+    adoptPreselectedPane();
     
     m_lastClickedIndex[m_featurePane] = index;
     int crateId = crateIdFromIndex(index);

--- a/src/library/features/crates/cratefeature.h
+++ b/src/library/features/crates/cratefeature.h
@@ -51,11 +51,12 @@ class CrateFeature : public LibraryFeature {
     void analyzeTracks(QList<TrackId>);
 
   public slots:
-    void activate();
-    void activateChild(const QModelIndex& index);
+    void activate() override;
+    void activateChild(const QModelIndex& index) override;
+    void invalidateChild() override;
     void activateCrate(int crateId);
-    void onRightClick(const QPoint& globalPos);
-    void onRightClickChild(const QPoint& globalPos, QModelIndex index);
+    void onRightClick(const QPoint& globalPos) override;
+    void onRightClickChild(const QPoint& globalPos, const QModelIndex& index) override;
 
     void slotCreateCrate();
     void slotDeleteCrate();

--- a/src/library/features/libraryfolder/libraryfoldermodel.cpp
+++ b/src/library/features/libraryfolder/libraryfoldermodel.cpp
@@ -32,7 +32,8 @@ LibraryFolderModel::LibraryFolderModel(LibraryFeature* pFeature,
     reloadTree();
 }
 
-bool LibraryFolderModel::setData(const QModelIndex& index, const QVariant& value, int role) {
+bool LibraryFolderModel::setData(
+        const QModelIndex& index, const QVariant& value, int role) {
     if (role == AbstractRole::RoleSettings) {
         m_folderRecursive = value.toBool();
         m_pConfig->set(ConfigKey("[Library]", "FolderRecursive"), 
@@ -75,6 +76,8 @@ QVariant LibraryFolderModel::data(const QModelIndex& index, int role) const {
 }
 
 void LibraryFolderModel::reloadTree() {
+    //qDebug() <<  "LibraryFolderModel::reloadTree()";
+    beginResetModel();
     // Remove current root
     setRootItem(new TreeItem(m_pFeature));
 
@@ -109,6 +112,7 @@ void LibraryFolderModel::reloadTree() {
         // For each source folder create the tree
         createTreeForLibraryDir(dir, query);
     }
+    endResetModel();
 }
 
 void LibraryFolderModel::createTreeForLibraryDir(const QString& dir, QSqlQuery& query) {

--- a/src/library/features/maintenance/maintenancefeature.cpp
+++ b/src/library/features/maintenance/maintenancefeature.cpp
@@ -19,7 +19,9 @@ MaintenanceFeature::MaintenanceFeature(UserSettingsPointer pConfig,
           kMissingTitle(tr("Missing Tracks")),
           m_pHiddenView(nullptr),
           m_pMissingView(nullptr),
-          m_pTab(nullptr) {
+          m_pTab(nullptr),
+          m_idExpandedHidden(-1),
+          m_idExpandedMissing(-1) {
 
 }
 
@@ -112,8 +114,7 @@ QWidget* MaintenanceFeature::createPaneWidget(KeyboardEventFilter* pKeyboard,
 
 void MaintenanceFeature::slotTabIndexChanged(int index) {
     QPointer<WTrackTableView> pTable = getFocusedTable();
-
-    DEBUG_ASSERT_AND_HANDLE(!pTable.isNull()) {
+    if (pTable.isNull()) {
         return;
     }
     pTable->setSortingEnabled(false);

--- a/src/library/features/maintenance/maintenancefeature.cpp
+++ b/src/library/features/maintenance/maintenancefeature.cpp
@@ -56,8 +56,8 @@ void MaintenanceFeature::selectionChanged(const QItemSelection&,
         return;
     }
 
-    auto it = m_idPaneCurrent.find(m_featurePane);
-    if (it == m_idPaneCurrent.end()) {
+    auto it = m_idPaneCurrent.constFind(m_featurePane);
+    if (it == m_idPaneCurrent.constEnd()) {
         return;
     }
 

--- a/src/library/features/mixxxlibrary/mixxxlibraryfeature.cpp
+++ b/src/library/features/mixxxlibrary/mixxxlibraryfeature.cpp
@@ -194,6 +194,8 @@ void MixxxLibraryFeature::activate() {
 
 void MixxxLibraryFeature::activateChild(const QModelIndex& index) {
     m_lastClickedIndex = index;
+    if (!index.isValid()) return;
+
     QString query = index.data(AbstractRole::RoleQuery).toString();
     //qDebug() << "MixxxLibraryFeature::activateChild" << query;
     
@@ -207,6 +209,10 @@ void MixxxLibraryFeature::activateChild(const QModelIndex& index) {
     switchToFeature();
     showBreadCrumb(index.data(AbstractRole::RoleBreadCrumb).toString(), getIcon());
     restoreSearch(query);
+}
+
+void MixxxLibraryFeature::invalidateChild() {
+    m_lastClickedIndex = QModelIndex();
 }
 
 void MixxxLibraryFeature::onRightClickChild(const QPoint& pos, 

--- a/src/library/features/mixxxlibrary/mixxxlibraryfeature.cpp
+++ b/src/library/features/mixxxlibrary/mixxxlibraryfeature.cpp
@@ -41,86 +41,22 @@ MixxxLibraryFeature::MixxxLibraryFeature(UserSettingsPointer pConfig,
                                          TrackCollection* pTrackCollection)
         : LibraryFeature(pConfig, pLibrary, pTrackCollection, parent),
           m_trackDao(pTrackCollection->getTrackDAO()) {
-    QStringList columns;
-    columns << "library." + LIBRARYTABLE_ID
-            << "library." + LIBRARYTABLE_PLAYED
-            << "library." + LIBRARYTABLE_TIMESPLAYED
-            //has to be up here otherwise Played and TimesPlayed are not show
-            << "library." + LIBRARYTABLE_ALBUMARTIST
-            << "library." + LIBRARYTABLE_ALBUM
-            << "library." + LIBRARYTABLE_ARTIST
-            << "library." + LIBRARYTABLE_TITLE
-            << "library." + LIBRARYTABLE_YEAR
-            << "library." + LIBRARYTABLE_RATING
-            << "library." + LIBRARYTABLE_GENRE
-            << "library." + LIBRARYTABLE_COMPOSER
-            << "library." + LIBRARYTABLE_GROUPING
-            << "library." + LIBRARYTABLE_TRACKNUMBER
-            << "library." + LIBRARYTABLE_KEY
-            << "library." + LIBRARYTABLE_KEY_ID
-            << "library." + LIBRARYTABLE_BPM
-            << "library." + LIBRARYTABLE_BPM_LOCK
-            << "library." + LIBRARYTABLE_DURATION
-            << "library." + LIBRARYTABLE_BITRATE
-            << "library." + LIBRARYTABLE_REPLAYGAIN
-            << "library." + LIBRARYTABLE_FILETYPE
-            << "library." + LIBRARYTABLE_DATETIMEADDED
-            << "track_locations.location"
-            << "track_locations.fs_deleted"
-            << "track_locations.directory"
-            << "library." + LIBRARYTABLE_COMMENT
-            << "library." + LIBRARYTABLE_MIXXXDELETED
-            << "library." + LIBRARYTABLE_COVERART_SOURCE
-            << "library." + LIBRARYTABLE_COVERART_TYPE
-            << "library." + LIBRARYTABLE_COVERART_LOCATION
-            << "library." + LIBRARYTABLE_COVERART_HASH;
 
-    QSqlQuery query(pTrackCollection->getDatabase());
-    QString tableName = "library_cache_view";
-    QString queryString = QString(
-        "CREATE TEMPORARY VIEW IF NOT EXISTS %1 AS "
-        "SELECT %2 FROM library "
-        "INNER JOIN track_locations ON library.location = track_locations.id")
-            .arg(tableName, columns.join(","));
-    qDebug() << queryString;
-    query.prepare(queryString);
-    if (!query.exec()) {
-        LOG_FAILED_QUERY(query);
-    }
-
-    // Strip out library. and track_locations.
-    for (QStringList::iterator it = columns.begin();
-         it != columns.end(); ++it) {
-        if (it->startsWith("library.")) {
-            *it = it->replace("library.", "");
-        } else if (it->startsWith("track_locations.")) {
-            *it = it->replace("track_locations.", "");
-        }
-    }
-
-    BaseTrackCache* pBaseTrackCache = new BaseTrackCache(
-            pTrackCollection, tableName, LIBRARYTABLE_ID, columns, true);
+    m_pBaseTrackCache = pTrackCollection->getTrackSource();
     connect(&m_trackDao, SIGNAL(trackDirty(TrackId)),
-            pBaseTrackCache, SLOT(slotTrackDirty(TrackId)));
+            m_pBaseTrackCache.data(), SLOT(slotTrackDirty(TrackId)));
     connect(&m_trackDao, SIGNAL(trackClean(TrackId)),
-            pBaseTrackCache, SLOT(slotTrackClean(TrackId)));
+            m_pBaseTrackCache.data(), SLOT(slotTrackClean(TrackId)));
     connect(&m_trackDao, SIGNAL(trackChanged(TrackId)),
-            pBaseTrackCache, SLOT(slotTrackChanged(TrackId)));
+            m_pBaseTrackCache.data(), SLOT(slotTrackChanged(TrackId)));
     connect(&m_trackDao, SIGNAL(tracksAdded(QSet<TrackId>)),
-            pBaseTrackCache, SLOT(slotTracksAdded(QSet<TrackId>)));
+            m_pBaseTrackCache.data(), SLOT(slotTracksAdded(QSet<TrackId>)));
     connect(&m_trackDao, SIGNAL(tracksRemoved(QSet<TrackId>)),
-            pBaseTrackCache, SLOT(slotTracksRemoved(QSet<TrackId>)));
+            m_pBaseTrackCache.data(), SLOT(slotTracksRemoved(QSet<TrackId>)));
     connect(&m_trackDao, SIGNAL(dbTrackAdded(TrackPointer)),
-            pBaseTrackCache, SLOT(slotDbTrackAdded(TrackPointer)));
+            m_pBaseTrackCache.data(), SLOT(slotDbTrackAdded(TrackPointer)));
 
     setChildModel(new MixxxLibraryTreeModel(this, m_pTrackCollection, m_pConfig));
-    
-    m_pBaseTrackCache = QSharedPointer<BaseTrackCache>(pBaseTrackCache);
-    
-    
-    pTrackCollection->setTrackSource(m_pBaseTrackCache);
-
-    // These rely on the 'default' track source being present.
     m_pLibraryTableModel = new LibraryTableModel(this, pTrackCollection, "mixxx.db.model.library");
 }
 

--- a/src/library/features/mixxxlibrary/mixxxlibraryfeature.h
+++ b/src/library/features/mixxxlibrary/mixxxlibraryfeature.h
@@ -51,9 +51,10 @@ class MixxxLibraryFeature : public LibraryFeature {
     QWidget* createInnerSidebarWidget(KeyboardEventFilter* pKeyboard) override;
 
   public slots:
-    void activate();
-    void activateChild(const QModelIndex& index);
+    void activate() override;
+    void activateChild(const QModelIndex& index) override;
     void onRightClickChild(const QPoint& pos, const QModelIndex&) override;
+    void invalidateChild() override;
     void refreshLibraryModels();
 
     void onSearch(const QString&) override;

--- a/src/library/features/mixxxlibrary/mixxxlibrarytreemodel.cpp
+++ b/src/library/features/mixxxlibrary/mixxxlibrarytreemodel.cpp
@@ -133,7 +133,7 @@ bool MixxxLibraryTreeModel::setData(const QModelIndex& index, const QVariant& va
 
 void MixxxLibraryTreeModel::reloadTree() {    
     //qDebug() << "LibraryTreeModel::reloadTracksTree";
-    
+    beginResetModel();
     // Create root item
     TreeItem* pRootItem = new TreeItem();
     pRootItem->setLibraryFeature(m_pFeature);
@@ -148,7 +148,7 @@ void MixxxLibraryTreeModel::reloadTree() {
     // Deletes the old root item if the previous root item was not null
     setRootItem(pRootItem);
     createTracksTree();
-    triggerRepaint();
+    endResetModel();
 }
 
 void MixxxLibraryTreeModel::coverFound(const QObject* requestor, int requestReference,

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -208,6 +208,15 @@ void Library::addFeature(LibraryFeature* feature) {
             this, SIGNAL(enableCoverArtDisplay(bool)));
     connect(feature, SIGNAL(trackSelected(TrackPointer)),
             this, SIGNAL(trackSelected(TrackPointer)));
+
+    connect(feature, SIGNAL(hovered(LibraryFeature*)),
+            this, SLOT(slotSetHoveredFeature(LibraryFeature*)));
+    connect(feature, SIGNAL(leaved(LibraryFeature*)),
+            this, SLOT(slotResetHoveredFeature(LibraryFeature*)));
+    connect(feature, SIGNAL(focusIn(LibraryFeature*)),
+            this, SLOT(slotSetFocusedFeature(LibraryFeature*)));
+    connect(feature, SIGNAL(focusOut(LibraryFeature*)),
+            this, SLOT(slotResetFocusedFeature(LibraryFeature*)));
 }
 
 void Library::switchToFeature(LibraryFeature* pFeature) {

--- a/src/library/library.cpp
+++ b/src/library/library.cpp
@@ -175,7 +175,7 @@ void Library::destroyInterface() {
     }
     
     for (LibraryFeature* f : m_features) {
-        f->setFeaturePane(-1);
+        f->setFeaturePaneId(-1);
     }
     m_panes.clear();
 }
@@ -296,7 +296,7 @@ void Library::paneFocused(LibraryPaneManager* pPane) {
     
     if (pPane != m_pSidebarExpanded) {
         m_focusedPaneId = pPane->getPaneId();
-        pPane->getCurrentFeature()->setFeaturePane(m_focusedPaneId);
+        pPane->getCurrentFeature()->setFeaturePaneId(m_focusedPaneId);
         DEBUG_ASSERT_AND_HANDLE(m_focusedPaneId != -1) {
             return;
         }
@@ -355,15 +355,14 @@ void Library::onSkinLoadFinished() {
                 first = false;
                 // Set the first pane as saved pane to all features
                 for (LibraryFeature* pFeature : m_features) {
-                    pFeature->setSavedPane(m_preselectedPane);
+                    pFeature->setFeaturePaneId(m_preselectedPane);
                 }
             }
             
             m_savedFeatures[m_preselectedPane] = *itF;
             (*itP)->setCurrentFeature(*itF);
             
-            (*itF)->setFeaturePane(m_preselectedPane);
-            (*itF)->setSavedPane(m_preselectedPane);
+            (*itF)->setFeaturePaneId(m_preselectedPane);
             (*itF)->activate();
             
             ++itP;
@@ -373,7 +372,7 @@ void Library::onSkinLoadFinished() {
         // The first pane always shows the Mixxx Library feature on start
         m_preselectedPane = m_focusedPaneId = m_panes.begin().key();
         handleFocus();
-        (*m_features.begin())->setFeaturePane(m_preselectedPane);
+        (*m_features.begin())->setFeaturePaneId(m_preselectedPane);
         slotActivateFeature(*m_features.begin());
     }
     else {
@@ -493,14 +492,14 @@ void Library::paneUncollapsed(int paneId) {
     if (pFeature == nullptr) {
         return;
     }
-    pFeature->setFeaturePane(pPane->getPaneId());
+    pFeature->setFeaturePaneId(pPane->getPaneId());
     
     for (LibraryPaneManager* pPane : m_panes) {
         int auxId = pPane->getPaneId();
         if (auxId != paneId && pFeature == pPane->getCurrentFeature()) {
             LibraryFeature* pSaved = m_savedFeatures[auxId];
             pPane->switchToFeature(pSaved);
-            pSaved->setFeaturePane(auxId);
+            pSaved->setFeaturePaneId(auxId);
             pSaved->activate();
         }
     }    
@@ -510,14 +509,13 @@ void Library::slotActivateFeature(LibraryFeature* pFeature) {
     int selectedPane = m_preselectedPane;
     if (selectedPane  < 0) {
         // No pane is preselected, use the saved pane instead
-        selectedPane  = pFeature->getSavedPane();
+        selectedPane  = pFeature->getFeaturePaneId();
     }
     
     bool featureActivated = false;
     LibraryPaneManager* pSelectedPane = m_panes.value(selectedPane);
     if (pSelectedPane) {
-        pFeature->setSavedPane(selectedPane);
-        pFeature->setFeaturePane(selectedPane);
+        pFeature->setFeaturePaneId(selectedPane);
 
         if (pSelectedPane->getCurrentFeature() != pFeature) {
             pSelectedPane->setCurrentFeature(pFeature);
@@ -556,14 +554,14 @@ void Library::slotSetTrackTableRowHeight(int rowHeight) {
 
 void Library::slotSetHoveredFeature(LibraryFeature* pFeature) {
     m_hoveredFeature = pFeature;
-    m_previewPreselectedPane = pFeature->getSavedPane();
+    m_previewPreselectedPane = pFeature->getFeaturePaneId();
     handlePreselection();
 }
 
 void Library::slotResetHoveredFeature(LibraryFeature* pFeature) {
     if (pFeature == m_hoveredFeature) {
         if (m_focusedFeature) {
-            m_previewPreselectedPane = m_focusedFeature->getSavedPane();
+            m_previewPreselectedPane = m_focusedFeature->getFeaturePaneId();
         } else {
             m_previewPreselectedPane = -1;
         }
@@ -574,14 +572,14 @@ void Library::slotResetHoveredFeature(LibraryFeature* pFeature) {
 
 void Library::slotSetFocusedFeature(LibraryFeature* pFeature) {
     m_focusedFeature = pFeature;
-    m_previewPreselectedPane = pFeature->getSavedPane();
+    m_previewPreselectedPane = pFeature->getFeaturePaneId();
     handlePreselection();
 }
 
 void Library::slotResetFocusedFeature(LibraryFeature* pFeature) {
     if (pFeature == m_focusedFeature) {
         if (m_hoveredFeature) {
-            m_previewPreselectedPane = m_hoveredFeature->getSavedPane();
+            m_previewPreselectedPane = m_hoveredFeature->getFeaturePaneId();
         } else {
             m_previewPreselectedPane = -1;
         }
@@ -707,13 +705,8 @@ void Library::handleFocus() {
 
 void Library::handlePreselection() {
     for (LibraryPaneManager* pPane : m_panes) {
-
-
         pPane->setPreselected(false);
         pPane->setPreviewed(false);
-
-
-
     }
     LibraryPaneManager* pSelectedPane = m_panes.value(m_preselectedPane);
     if (pSelectedPane) {

--- a/src/library/library.h
+++ b/src/library/library.h
@@ -153,6 +153,7 @@ public:
     LibraryPaneManager* getFocusedPane();
     LibraryPaneManager* getPreselectedPane();
     
+    void createTrackCache();
     void createFeatures(UserSettingsPointer pConfig, PlayerManagerInterface *pPlayerManager);
     
     void handleFocus();

--- a/src/library/libraryfeature.cpp
+++ b/src/library/libraryfeature.cpp
@@ -179,6 +179,7 @@ QList<SavedSearchQuery> LibraryFeature::getSavedQueries() const {
 WTrackTableView* LibraryFeature::createTableWidget(int paneId) {
     WTrackTableView* pTrackTableView = 
             new WTrackTableView(nullptr, m_pConfig, m_pTrackCollection, true);
+    m_trackTablesByPaneId[paneId] = pTrackTableView;
         
     WMiniViewScrollBar* pScrollBar = new WMiniViewScrollBar(pTrackTableView);
     pTrackTableView->setScrollBar(pScrollBar);
@@ -196,7 +197,6 @@ WTrackTableView* LibraryFeature::createTableWidget(int paneId) {
             pTrackTableView, SLOT(setTrackTableFont(QFont)));
     connect(m_pLibrary, SIGNAL(setTrackTableRowHeight(int)),
             pTrackTableView, SLOT(setTrackTableRowHeight(int)));
-    m_trackTablesByPaneId[paneId] = pTrackTableView;
     
     return pTrackTableView;
 }

--- a/src/library/libraryfeature.cpp
+++ b/src/library/libraryfeature.cpp
@@ -36,8 +36,7 @@ LibraryFeature::LibraryFeature(UserSettingsPointer pConfig,
           m_pLibrary(pLibrary),
           m_pTrackCollection(pTrackCollection),
           m_savedDAO(m_pTrackCollection->getSavedQueriesDAO()),
-          m_featurePane(-1),
-          m_savedPane(-1) {
+          m_featurePane(-1) {
 }
 
 LibraryFeature::~LibraryFeature() {
@@ -104,7 +103,7 @@ QWidget *LibraryFeature::createSidebarWidget(KeyboardEventFilter* pKeyboard) {
     return pContainer;
 }
 
-void LibraryFeature::setFeaturePane(int paneId) {
+void LibraryFeature::setFeaturePaneId(int paneId) {
     m_featurePane = paneId;
 }
 
@@ -112,20 +111,18 @@ int LibraryFeature::getFeaturePaneId() {
     return m_featurePane;
 }
 
-void LibraryFeature::setSavedPane(int paneId) {
-    m_savedPane = paneId;
-}
-
-int LibraryFeature::getSavedPane() {
-    return m_savedPane;
-}
-
 int LibraryFeature::getFocusedPane() {
     return m_pLibrary->getFocusedPaneId();
 }
 
-int LibraryFeature::getPreselectedPane() {
-    return m_pLibrary->getPreselectedPaneId();
+void LibraryFeature::adoptPreselectedPane() {
+    int preselectedPane = m_pLibrary->getPreselectedPaneId();
+    if (preselectedPane >= 0 &&
+            m_featurePane != preselectedPane) {
+        m_featurePane = preselectedPane;
+        // Refresh preselect button
+        emit focusIn(this);
+    }
 }
 
 SavedSearchQuery LibraryFeature::saveQuery(SavedSearchQuery sQuery) {

--- a/src/library/libraryfeature.cpp
+++ b/src/library/libraryfeature.cpp
@@ -215,6 +215,8 @@ WLibrarySidebar* LibraryFeature::createLibrarySidebarWidget(KeyboardEventFilter*
     pMiniView->setTreeView(pSidebar);
     pMiniView->setModel(pModel);
     pSidebar->setVerticalScrollBar(pMiniView);
+    // invalidate probably stored QModelIndex
+    invalidateChild();
     
     connect(pSidebar, SIGNAL(pressed(const QModelIndex&)),
             this, SLOT(activateChild(const QModelIndex&)));

--- a/src/library/libraryfeature.cpp
+++ b/src/library/libraryfeature.cpp
@@ -259,7 +259,9 @@ void LibraryFeature::restoreSearch(const QString& search) {
 }
 
 void LibraryFeature::restoreSaveButton() {
-    m_pLibrary->restoreSaveButton(m_featurePane);
+    if (m_featurePane >= 0) {
+        m_pLibrary->restoreSaveButton(m_featurePane);
+    }
 }
 
 void LibraryFeature::showBreadCrumb(TreeItem *pTree) {

--- a/src/library/libraryfeature.cpp
+++ b/src/library/libraryfeature.cpp
@@ -230,12 +230,21 @@ WLibrarySidebar* LibraryFeature::createLibrarySidebarWidget(KeyboardEventFilter*
     connect(this, SIGNAL(selectIndex(const QModelIndex&)),
             pSidebar, SLOT(selectIndex(const QModelIndex&)));
     
+    connect(pSidebar, SIGNAL(hovered()),
+            this, SLOT(slotSetHoveredSidebar()));
+    connect(pSidebar, SIGNAL(leaved()),
+            this, SLOT(slotResetHoveredSidebar()));
+    connect(pSidebar, SIGNAL(focusIn()),
+            this, SLOT(slotSetFocusedSidebar()));
+    connect(pSidebar, SIGNAL(focusOut()),
+            this, SLOT(slotResetFocusedSidebar()));
+
     return pSidebar;
 }
 
 void LibraryFeature::showTrackModel(QAbstractItemModel *model) {
-    auto it = m_trackTablesByPaneId.find(m_featurePane);
-    if (it == m_trackTablesByPaneId.end() || it->isNull()) {
+    auto it = m_trackTablesByPaneId.constFind(m_featurePane);
+    if (it == m_trackTablesByPaneId.constEnd() || it->isNull()) {
         return;
     }
     (*it)->loadTrackModel(model);
@@ -272,8 +281,8 @@ void LibraryFeature::showBreadCrumb() {
 }
 
 WTrackTableView* LibraryFeature::getFocusedTable() {
-    auto it = m_trackTablesByPaneId.find(m_featurePane);
-    if (it == m_trackTablesByPaneId.end() || it->isNull()) {
+    auto it = m_trackTablesByPaneId.constFind(m_featurePane);
+    if (it == m_trackTablesByPaneId.constEnd() || it->isNull()) {
         return nullptr;
     }
     return *it;

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -84,6 +84,8 @@ class LibraryFeature : public QObject {
     virtual void activate() = 0;
     // called when you single click on a child item, e.g., a concrete playlist or crate
     virtual void activateChild(const QModelIndex&) {}
+    // called when the QModelIndex passed by activateChild() becomes invalid.
+    virtual void invalidateChild() {}
     // called when you right click on the root item
     virtual void onRightClick(const QPoint&) {}
     // called when you right click on a child item, e.g., a concrete playlist or crate

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -69,14 +69,11 @@ class LibraryFeature : public QObject {
     
     virtual TreeItemModel* getChildModel() = 0;
     
-    virtual void setFeaturePane(int paneId);
+    virtual void setFeaturePaneId(int paneId);
     int getFeaturePaneId();
     
-    void setSavedPane(int paneId);
-    int getSavedPane();
-    
     int getFocusedPane();
-    int getPreselectedPane();
+    void adoptPreselectedPane();
     
     virtual SavedSearchQuery saveQuery(SavedSearchQuery sQuery);
     virtual void restoreQuery(int id);
@@ -167,7 +164,6 @@ class LibraryFeature : public QObject {
     SavedQueriesDAO& m_savedDAO;
     
     int m_featurePane;
-    int m_savedPane;
     
   private: 
     QStringList getPlaylistFiles(QFileDialog::FileMode mode);

--- a/src/library/libraryfeature.h
+++ b/src/library/libraryfeature.h
@@ -98,6 +98,11 @@ class LibraryFeature : public QObject {
     
     virtual void onSearch(const QString&) {}
     
+    void slotSetHoveredSidebar() { emit hovered(this); };
+    void slotResetHoveredSidebar() { emit leaved(this); };
+    void slotSetFocusedSidebar() { emit focusIn(this); };
+    void slotResetFocusedSidebar() { emit focusOut(this); };
+
   signals:
     
     void loadTrack(TrackPointer);
@@ -115,6 +120,11 @@ class LibraryFeature : public QObject {
     void enableCoverArtDisplay(bool);
     void trackSelected(TrackPointer);
     
+    void hovered(LibraryFeature* pLibraryFeature);
+    void leaved(LibraryFeature* pLibraryFeature);
+    void focusIn(LibraryFeature* pLibraryFeature);
+    void focusOut(LibraryFeature* pLibraryFeature);
+
   protected slots:
     void restoreSaveButton();
     

--- a/src/library/treeitemmodel.cpp
+++ b/src/library/treeitemmodel.cpp
@@ -199,7 +199,8 @@ void TreeItemModel::setRootItem(TreeItem *item) {
  * Before you can resize the data model dynamically by using 'insertRows' and 'removeRows'
  * make sure you have initialized
  */
-bool TreeItemModel::insertRows(QList<TreeItem*> &data, int position, int rows, const QModelIndex &parent) {
+bool TreeItemModel::insertRows(
+        QList<TreeItem*>& data, int position, int rows, const QModelIndex &parent) {
     if (rows == 0) {
         return true;
     }
@@ -239,6 +240,7 @@ void TreeItemModel::triggerRepaint() {
     emit(dataChanged(left, right));
 }
 
+//static
 QString TreeItemModel::getBreadCrumbString(TreeItem* pTree) {    
     // Base case
     if (pTree == nullptr || pTree->getFeature() == nullptr) {
@@ -254,6 +256,7 @@ QString TreeItemModel::getBreadCrumbString(TreeItem* pTree) {
     return next % QLatin1String(" > ") % text;
 }
 
+//static
 QSize TreeItemModel::getDefaultIconSize() {
     return QSize(32, 32);
 }

--- a/src/widget/wlibrarysidebar.cpp
+++ b/src/widget/wlibrarysidebar.cpp
@@ -328,3 +328,24 @@ bool WLibrarySidebar::paste() {
 
     return pTreeModel->dropAccept(destIndex, pMimeData->urls(), nullptr);
 }
+
+void WLibrarySidebar::enterEvent(QEvent* pEvent) {
+    QTreeView::enterEvent(pEvent);
+    emit(hovered());
+}
+
+void WLibrarySidebar::leaveEvent(QEvent* pEvent) {
+    QTreeView::leaveEvent(pEvent);
+    emit(leaved());
+}
+
+void WLibrarySidebar::focusInEvent(QFocusEvent* pEvent) {
+    QTreeView::focusInEvent(pEvent);
+    emit(focusIn());
+}
+
+void WLibrarySidebar::focusOutEvent(QFocusEvent* pEvent) {
+    QTreeView::focusOutEvent(pEvent);
+    emit(focusOut());
+}
+

--- a/src/widget/wlibrarysidebar.h
+++ b/src/widget/wlibrarysidebar.h
@@ -45,8 +45,17 @@ class WLibrarySidebar : public QTreeView, public WBaseWidget {
   signals:
     void rightClicked(const QPoint&, const QModelIndex&);
 
+    void hovered();
+    void leaved();
+    void focusIn();
+    void focusOut();
+
   protected:
     bool event(QEvent* pEvent) override;
+    void enterEvent(QEvent*) override;
+    void leaveEvent(QEvent*) override;
+    void focusInEvent(QFocusEvent*) override;
+    void focusOutEvent(QFocusEvent*) override;
 
   private:
     bool paste();

--- a/src/widget/wtristatebutton.cpp
+++ b/src/widget/wtristatebutton.cpp
@@ -8,7 +8,7 @@ WTriStateButton::WTriStateButton(QWidget* parent)
 }
 
 void WTriStateButton::setChecked(bool value) {
-    qDebug() << this << "setChecked" << value;
+    //qDebug() << this << "setChecked" << value;
     // This omits the Hovered state
     State state = value ? State::Active : State::Unactive;
     setState(state);
@@ -29,7 +29,7 @@ WTriStateButton::State WTriStateButton::getState() const {
 }
 
 void WTriStateButton::setHovered(bool value) {
-    qDebug() << this << "setHovered" << value;
+    //qDebug() << this << "setHovered" << value;
     State state = value ? State::Hovered : State::Unactive;
     setState(state);
 }


### PR DESCRIPTION
Here is the a new step. 
The preselelct button works now also for playlist and crates. 

There is now an issue with the single pane features like Library and browse. 
You can now switch the breadcrumb and the search box to the right pane, while the track table sticks left. Very confusing. 
What will be the best way to solve is? Make all views multi pane aware... of just fix the issue? 
I have tries to fix the issue, but is seams to be somehow hard for me. Could you point me to the right direction?  